### PR TITLE
order the refs by the ref name, numerically to see which tag was last

### DIFF
--- a/lib/auto_tagger/base.rb
+++ b/lib/auto_tagger/base.rb
@@ -29,7 +29,7 @@ module AutoTagger
 
     def last_ref_from_previous_stage
       return unless previous_stage
-      refs_for_stage(previous_stage).last
+      ordered_refs_for_stage(previous_stage).last
     end
 
     def create_ref(commit = nil)
@@ -111,6 +111,14 @@ module AutoTagger
       matcher = /refs\/#{ref_path}\/#{Regexp.escape(stage)}\/.*/
       repo.refs.all.select do |ref|
         (ref.name =~ matcher) ? ref : nil
+      end
+    end
+
+    def ordered_refs_for_stage(stage)
+      ref_path = Regexp.escape(configuration.ref_path)
+      matcher = /refs\/#{ref_path}\/#{Regexp.escape(stage)}\/(.*)/
+      refs_for_stage(stage).sort do |ref1, ref2|
+        ref1.name.match(matcher)[1].to_i <=> ref2.name.match(matcher)[1].to_i
       end
     end
 

--- a/lib/auto_tagger/base.rb
+++ b/lib/auto_tagger/base.rb
@@ -118,7 +118,9 @@ module AutoTagger
       ref_path = Regexp.escape(configuration.ref_path)
       matcher = /refs\/#{ref_path}\/#{Regexp.escape(stage)}\/(.*)/
       refs_for_stage(stage).sort do |ref1, ref2|
-        ref1.name.match(matcher)[1].to_i <=> ref2.name.match(matcher)[1].to_i
+        name1 = ref1.name.match(matcher)[1].gsub(configuration.date_separator, "")
+        name2 = ref2.name.match(matcher)[1].gsub(configuration.date_separator, "")
+        name1.to_i <=> name2.to_i
       end
     end
 

--- a/spec/auto_tagger/base_spec.rb
+++ b/spec/auto_tagger/base_spec.rb
@@ -42,6 +42,18 @@ describe AutoTagger::Base do
       ref = AutoTagger::Git::Ref.new(base.repo, "41dee06050450ac", "refs/tags/ci/2003")
       base.last_ref_from_previous_stage.name.should == "refs/tags/ci/2003"
     end
+
+    it "should return the last ref with correct order (git show-ref is not ordered)" do
+      refs = %Q{
+        a80af49962c95a92df59a527a3ce60e22da290fc refs/tags/ci/1002
+        0e892ad1b308dd86c40f5fd60b3cddd58022d93e refs/tags/ci/997
+        b8d7ce86f1c6440080e0c315c7cc1c0fe702127f refs/tags/ci/999
+      }
+      base = AutoTagger::Base.new :stages => ["ci", "demo", "production"], :stage => "demo"
+      base.repo.stub(:read).and_return(refs)
+      ref = AutoTagger::Git::Ref.new(base.repo, "a80af49962c95a92df59a527a3ce60e22da290fc", "refs/tags/ci/1002")
+      base.last_ref_from_previous_stage.name.should == "refs/tags/ci/1002"
+    end
   end
 
   describe "#create_ref" do

--- a/spec/auto_tagger/base_spec.rb
+++ b/spec/auto_tagger/base_spec.rb
@@ -54,6 +54,18 @@ describe AutoTagger::Base do
       ref = AutoTagger::Git::Ref.new(base.repo, "a80af49962c95a92df59a527a3ce60e22da290fc", "refs/tags/ci/1002")
       base.last_ref_from_previous_stage.name.should == "refs/tags/ci/1002"
     end
+
+    it "should return the last ref with correct order using other date separator(git show-ref is not ordered)" do
+      refs = %Q{
+        a80af49962c95a92df59a527a3ce60e22da290fc refs/tags/ci/2011-09-09-18-17-43
+        0e892ad1b308dd86c40f5fd60b3cddd58022d93e refs/tags/ci/2011-09-09-19-17-43
+        b8d7ce86f1c6440080e0c315c7cc1c0fe702127f refs/tags/ci/2011-09-08-18-17-43
+      }
+      base = AutoTagger::Base.new :stages => ["ci", "demo", "production"], :stage => "demo", :date_separator => "-"
+      base.repo.stub(:read).and_return(refs)
+      ref = AutoTagger::Git::Ref.new(base.repo, "a80af49962c95a92df59a527a3ce60e22da290fc", "refs/tags/ci/2011-09-09-19-17-43")
+      base.last_ref_from_previous_stage.name.should == "refs/tags/ci/2011-09-09-19-17-43"
+    end
   end
 
   describe "#create_ref" do
@@ -139,9 +151,9 @@ describe AutoTagger::Base do
       base.repo.stub(:exec) { true }
       base.stub(:refs_for_stage) do
         [
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2010")
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2010")
         ]
       end
       base.repo.should_receive(:exec).with("update-ref -d refs/tags/ci/2008")
@@ -161,7 +173,7 @@ describe AutoTagger::Base do
 
     it "does not push if there are no tags" do
       base = AutoTagger::Base.new :stage => "ci"
-      base.stub(:refs_for_stage).with("ci") {[]}
+      base.stub(:refs_for_stage).with("ci") { [] }
       base.repo.should_not_receive(:exec)
       base.delete_on_remote
     end
@@ -171,9 +183,9 @@ describe AutoTagger::Base do
       base.repo.stub(:exec) { true }
       base.stub(:refs_for_stage).with("ci") do
         [
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
-          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2010")
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
+            AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2010")
         ]
       end
       base.repo.should_receive(:exec).with("push origin :refs/tags/ci/2008 :refs/tags/ci/2009")
@@ -234,15 +246,15 @@ describe AutoTagger::Base do
       base = AutoTagger::Base.new :stage => "ci"
       base.repo.stub(:exec) { true }
       refs = [
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/auto_tags/ci/2008"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags-ci/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/heads/master")
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/auto_tags/ci/2008"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags-ci/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/heads/master")
       ]
       base.repo.stub(:refs) { mock("RefSet", :all => refs) }
       base.refs_for_stage("ci").should == [
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009")
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009")
       ]
     end
   end
@@ -261,18 +273,18 @@ describe AutoTagger::Base do
       base = AutoTagger::Base.new :stage => "ci", :stages => ["ci", "demo", "production"]
       base.repo.stub(:exec) { true }
       refs = [
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2008"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2008"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2009")
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2008"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2008"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2008"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2009")
       ]
       base.repo.stub(:refs) { mock("RefSet", :all => refs) }
       base.release_tag_entries.should == [
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2009"),
-        AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2009")
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/ci/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/demo/2009"),
+          AutoTagger::Git::Ref.new(base.repo, "abc123", "refs/tags/production/2009")
       ]
     end
   end


### PR DESCRIPTION
git show-refs returns refs ordered alphabetically, not by date. order the refs by the ref name, numerically
