### PR TITLE
Only set explicitly defined Capistrano variables.

### DIFF
--- a/lib/auto_tagger/capistrano_helper.rb
+++ b/lib/auto_tagger/capistrano_helper.rb
@@ -41,14 +41,14 @@ module AutoTagger
       if ! variables[:auto_tagger_dry_run].nil?
         options[:dry_run] = variables[:auto_tagger_dry_run]
       else
-        options[:dry_run] = variables[:dry_run]
+        options[:dry_run] = variables[:dry_run] if variables.has_key?(:dry_run)
       end
 
       [
         :date_separator, :push_refs, :fetch_refs, :remote, :ref_path, :offline,
         :verbose, :refs_to_keep, :executable, :opts_file
       ].each do |key|
-        options[key] = variables[:"auto_tagger_#{key}"]
+        options[key] = variables[:"auto_tagger_#{key}"] if variables.has_key?(:"auto_tagger_#{key}")
       end
 
       options

--- a/spec/auto_tagger/capistrano_helper_spec.rb
+++ b/spec/auto_tagger/capistrano_helper_spec.rb
@@ -82,8 +82,12 @@ describe AutoTagger::CapistranoHelper do
       :executable,
       :opts_file
     ].each do |key|
-      it "includes :#{key}" do
-        helper = AutoTagger::CapistranoHelper.new :"auto_tagger_#{key}" => "value"
+      it "includes :#{key} when specified" do
+        helper = AutoTagger::CapistranoHelper.new({})
+        helper.auto_tagger_options.should_not have_key(key)
+
+        helper = AutoTagger::CapistranoHelper.new(:"auto_tagger_#{key}" => "value")
+        helper.auto_tagger_options.should have_key(key)
         helper.auto_tagger_options[key].should == "value"
       end
     end


### PR DESCRIPTION
Setting lookups use `Hash#fetch`, which will let you return a sensible
default only when the key doesn't exist. Previously, all settings were
being set to at least `nil`, regardless of whether the user had set a
Capistrano variable, which prevented any defaults from being applied.

This resolves #27.
