### PR TITLE
Update gemspec to restrict capistrano to <=2.14.2

### DIFF
--- a/auto_tagger.gemspec
+++ b/auto_tagger.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<capistrano>, [">= 2.5.3"])
+      s.add_runtime_dependency(%q<capistrano>, [">= 2.5.3", "<=2.14.2"])
     else
-      s.add_dependency(%q<capistrano>, [">= 2.5.3"])
+      s.add_dependency(%q<capistrano>, [">= 2.5.3", "<=2.14.2"])
     end
   else
-    s.add_dependency(%q<capistrano>, [">= 2.5.3"])
+    s.add_dependency(%q<capistrano>, [">= 2.5.3", "<=2.14.2"])
   end
 end
 


### PR DESCRIPTION
The Gemfile has the restriction but the gemspec did not.
